### PR TITLE
Added simple pytest plugin implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ and exit codes.
 ## Usage
 
 1. Install `pytest` >= 7.4 in your Python environment.
-2. Copy the [conftest.py](./conftest.py) into your project root.
+2. Copy the [conftest.py](./conftest.py) into your project root. Or install as pytest plugin with `pip install git+https://github.com/guidorice/mojo-pytest.git`
 3. Use the project layout described in here.
 4. Run `pytest` from your project root. [See also pytest docs](https://docs.pytest.org). Examples:
 
 ```shell
 # summary
-pytest 
+pytest
 
 # details
 pytest -v
@@ -68,7 +68,7 @@ $ pytest
 =========================== test session starts ============================
 platform darwin -- Python 3.11.5, pytest-7.4.0, pluggy-1.0.0
 rootdir: /Users/guidorice/mojo/mojo-pytest
-collected 8 items                                                          
+collected 8 items
 
 example/tests/mod_a/test_convert.mojo .                              [ 12%]
 example/tests/mod_a/test_convert_different.mojo .                    [ 25%]

--- a/pytest_mojo/plugin.py
+++ b/pytest_mojo/plugin.py
@@ -1,0 +1,101 @@
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from pytest import Package, File, Item
+
+MOJO_CMD = ["mojo", "run", "-I", "."]
+"""
+Mojo command to be run by pytest. This assumes your Mojo package is a subdirectory of cwd.
+"""
+
+TEST_PREFIX = "test_"
+"""
+Examples of test prefix: `test_something.mojo` or `test_xyz.🔥`
+"""
+
+TEST_ITEM_PREFIX = "#"
+"""
+By convention, a comment line (hashtag) signals the test item name.
+"""
+
+
+def pytest_collect_file(parent: Package, file_path: Path) -> File | None:
+    if file_path.suffix in (".mojo", ".🔥") and file_path.name.startswith(TEST_PREFIX):
+        return MojoTestFile.from_parent(parent, path=file_path)
+    return None
+
+
+class MojoTestFile(File):
+    """
+    `mojo run` the source file, then parse the stdout and exit code into one or more `MojoTestItem`.
+    """
+
+    def collect(self):
+        warning_mode = self.config.getoption("-W")
+        mojo_src = str(self.path)
+        shell_cmd = MOJO_CMD.copy()
+        shell_cmd.append(mojo_src)
+
+        process = subprocess.run(shell_cmd, capture_output=True, text=True)
+
+        # early-out of there was a mojo parser error (tests cannot be discovered in this case)
+        if not process.stdout and process.returncode != 0:
+            raise MojoTestException(process.stderr)
+
+        # check stderr for any compile warnings, and create new test item dynamically (just a way to surface to pytest).
+        if process.stderr and warning_mode and "error" in warning_mode:
+            lines = process.stderr.split("\n")
+            lines = [line.strip() for line in lines]
+            for line in lines:
+                if "warning:" in line:
+                    yield MojoTestItem.from_parent(
+                        self, name="warning", spec=dict(stdout=[line], code=1)
+                    )
+
+        # extract result stdout into one or more MojoTestItem
+        lines = process.stdout.split("\n")
+        lines = [line.strip() for line in lines]
+        item_stdout = []
+        cur_item = None
+        for line in lines:
+            print(
+                line
+            )  # is captured by default: we can view this stdout with pytest -s
+
+            if line.startswith(TEST_ITEM_PREFIX):
+                if cur_item is not None:
+                    yield MojoTestItem.from_parent(
+                        self, name=cur_item, spec=dict(stdout=item_stdout, code=0)
+                    )
+                cur_item = line
+                item_stdout = []
+            else:
+                if line:
+                    item_stdout.append(line)
+        if cur_item is not None:
+            yield MojoTestItem.from_parent(
+                self,
+                name=cur_item,
+                spec=dict(stdout=item_stdout, code=process.returncode),
+            )
+
+
+class MojoTestItem(Item):
+    def __init__(self, *, name: str, parent, spec: dict[str, Any], **kwargs):
+        super().__init__(name, parent, **kwargs)
+        self.spec = spec
+
+    def runtest(self):
+        if self.spec["code"] != 0:
+            raise MojoTestException(self, self.spec["stdout"][-1])
+
+    def repr_failure(self, excinfo):
+        return str(excinfo.value)
+
+    def reportinfo(self):
+        return self.path, 0, self.name
+
+
+class MojoTestException(Exception):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="pytest-mojo",
+    version="0.1",
+    packages=find_packages(),
+    entry_points={"pytest11": ["mojo = pytest_mojo.plugin"]},
+    install_requires=["pytest"],
+)


### PR DESCRIPTION
This is a basic implementation of a pytest plugin `pytest-mojo` to build on top.
Note that the `pytest_mojo/plugin.py` module is an exact copy of `conftest.py` in case you think it is a good idea to move forward, we should have only one. My view is to have only the plugin one and change the README.md to point at that one and ask for a rename locally if people would rather not use the plugin approach.
The changes are as minimal as possible, and I am planning to do follow-up PRs with more improvements.
Please don't hesitate to change or discard the README.md updates I did, they are just an initial idea too.