### PR TITLE
Review of failed tests logic and Integration Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Run Tests
+
+on: ["push"]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          curl https://get.modular.com | MODULAR_AUTH=${{ secrets.MODULAR_AUTH }} sh -
+          modular auth ${{ secrets.MODULAR_AUTH }}
+          modular install mojo
+          pip install .
+      - name: Test
+        run: |
+          pytest example/tests/mod_b
+          if pytest example/tests/mod_a ; then
+            echo "This tests should fail"
+            exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
           pip install .
       - name: Test
         run: |
+          export MODULAR_HOME="/home/runner/.modular"
+          export PATH="/home/runner/.modular/pkg/packages.modular.com_mojo/bin:$PATH"
           pytest example/tests/mod_b
           if pytest example/tests/mod_a ; then
             echo "This tests should fail"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,4 @@ jobs:
           if pytest example/tests/mod_a ; then
             echo "This tests should fail"
             exit 1
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,28 @@ jobs:
           modular auth ${{ secrets.MODULAR_AUTH }}
           modular install mojo
           pip install .
-      - name: Test
+      - name: Integration Tests
         run: |
           export MODULAR_HOME="/home/runner/.modular"
           export PATH="/home/runner/.modular/pkg/packages.modular.com_mojo/bin:$PATH"
+
+          # Tests that do not fail
           pytest example/tests/mod_b
+
+          # Tests that should fail
           if pytest example/tests/mod_a ; then
             echo "This tests should fail"
             exit 1
           fi
+
+          # Test should fail becuase I am passing options for checking warnings
+          rm -rf ~/.modular/.mojo_cache
+          if pytest -W error example/tests/test_warning.mojo ; then
+            echo "This tests should fail"
+            exit 1
+          fi
+
+          # Test should not fail becuase I am not checking for warning
+          rm -rf ~/.modular/.mojo_cache
+          pytest example/tests/test_warning.mojo
+

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ and exit codes.
   - Each test file must have a `main` entry point function.
   - Each `main` function may call arbitrary functions and methods in your Mojo package.
   - Each test item must print a line with it's test name, prefixed with `#` (hashtag, comment) character, ex: `# test name`.
-  - Failed tests must raise Mojo `Error`. A helper function for assertions is in `example/tests/util.mojo`.
+  - Failed tests should use one of the standard [testing assertions](https://docs.modular.com/mojo/stdlib/testing/testing.html). A helper struct for tests is available in `example/tests/util.mojo`. Tests will also fail if a Mojo `Error` is raised or if an unhandled exception occurs. Note that this will not collect subsequent tests.
 - Mojo compiler warnings may optionally be handled as test failures, using the `pytest -W error` mode.
 
 ## Usage

--- a/example/tests/mod_a/test_convert.mojo
+++ b/example/tests/mod_a/test_convert.mojo
@@ -1,5 +1,5 @@
 from example.mod_a.impl import maths, convert, convert_different
-from example.tests.util import assert_true
+from example.tests.util import MojoTest
 
 
 fn main() raises:
@@ -7,8 +7,8 @@ fn main() raises:
 
 
 fn test_convert() raises:
-    print("# convert")
+    let test = MojoTest("convert")
     let x: Int = 42
     let expect = SIMD[DType.float64](42)
     let result = convert(x)
-    assert_true(result == expect, "convert unexpected result: " + String(result))
+    test.assert_true(result == expect, "convert unexpected result: " + String(result))

--- a/example/tests/mod_a/test_convert_different.mojo
+++ b/example/tests/mod_a/test_convert_different.mojo
@@ -1,5 +1,5 @@
 from example.mod_a.impl import maths, convert_different
-from example.tests.util import assert_true
+from example.tests.util import MojoTest
 
 
 fn main() raises:
@@ -7,8 +7,8 @@ fn main() raises:
 
 
 fn test_convert_different() raises:
-    print("# convert_different")
+    let test = MojoTest("convert_different")
     let x: Int = 8
     let expect = SIMD[DType.float16](8)
     let result = convert_different(x)
-    assert_true(result == expect, "convert unexpected result: " + String(result))
+    test.assert_true(result == expect, "convert unexpected result: " + String(result))

--- a/example/tests/mod_a/test_maths.mojo
+++ b/example/tests/mod_a/test_maths.mojo
@@ -27,4 +27,4 @@ fn test_maths_lotsmore() raises:
         let test = MojoTest("maths more: " + String(i))
         let result = maths(i)
         if result == i:
-            raise Error("bad maths: " + String(i))
+            test.assert_true(False, "bad maths: " + String(i))

--- a/example/tests/mod_a/test_maths.mojo
+++ b/example/tests/mod_a/test_maths.mojo
@@ -1,5 +1,5 @@
 from example.mod_a.impl import maths
-from example.tests.util import assert_true
+from example.tests.util import MojoTest
 
 
 fn main() raises:
@@ -9,22 +9,22 @@ fn main() raises:
 
 
 fn test_maths() raises:
-    print("# maths")
+    let test = MojoTest("maths")
     let result = maths(8)
     let expect = 64
-    assert_true(result == expect, "maths unexpected result: " + String(result))
+    test.assert_true(result == expect, "maths unexpected result: " + String(result))
 
 
 fn test_maths_more() raises:
-    print("# maths more")
+    let test = MojoTest("maths more")
     let result = maths(9)
     let expect = 81
-    assert_true(result == expect, "maths unexpected result: " + String(result))
+    test.assert_true(result == expect, "maths unexpected result: " + String(result))
 
 
 fn test_maths_lotsmore() raises:
     for i in range(40, 50):
-        print("# maths more: " + String(i))
+        let test = MojoTest("maths more: " + String(i))
         let result = maths(i)
         if result == i:
             raise Error("bad maths: " + String(i))

--- a/example/tests/mod_b/test_greet.mojo
+++ b/example/tests/mod_b/test_greet.mojo
@@ -1,5 +1,5 @@
 from example.mod_b.impl import greet
-from example.tests.util import assert_true
+from example.tests.util import MojoTest
 
 
 fn main() raises:
@@ -7,7 +7,7 @@ fn main() raises:
 
 
 fn test_greet() raises:
-    print("# greet result")
+    let test = MojoTest("greet result")
     let result = greet("guido")
     let expect = "Hey guido"
-    assert_true(result == expect, "greet unexpected result: " + String(result))
+    test.assert_true(result == expect, "greet unexpected result: " + String(result))

--- a/example/tests/test_warning.mojo
+++ b/example/tests/test_warning.mojo
@@ -1,3 +1,6 @@
+from example.tests.util import MojoTest
+
+
 fn main() raises:
     test_warning_is_collected()
 
@@ -10,6 +13,6 @@ fn test_warning_is_collected():
 
     This can be captured by running `pytest -W error` (warning -> error mode).
     """
-    print("# compiler warning")
+    let test = MojoTest("compiler warning")
     var x = 100
     print(x)

--- a/example/tests/util.mojo
+++ b/example/tests/util.mojo
@@ -1,9 +1,21 @@
 import testing
 
 
-fn assert_true(cond: Bool, message: String) raises:
+@value
+struct MojoTest:
     """
-    Wraps testing.assert_true, raises Error on assertion failure.
+    A utility struct for testing.
     """
-    if not testing.assert_true(cond, message):
-        raise Error(message)
+
+    var test_name: String
+
+    fn __init__(inout self, test_name: String):
+        self.test_name = test_name
+        print("# " + test_name)
+
+    fn assert_true(self, cond: Bool, message: String) raises:
+        """
+        Wraps testing.assert_true, raises Error on assertion failure.
+        """
+        if not testing.assert_true(cond, message):
+            raise Error(message)

--- a/example/tests/util.mojo
+++ b/example/tests/util.mojo
@@ -17,5 +17,4 @@ struct MojoTest:
         """
         Wraps testing.assert_true, raises Error on assertion failure.
         """
-        if not testing.assert_true(cond, message):
-            raise Error(message)
+        _ = testing.assert_true(cond, message)

--- a/example/tests/util.mojo
+++ b/example/tests/util.mojo
@@ -13,8 +13,8 @@ struct MojoTest:
         self.test_name = test_name
         print("# " + test_name)
 
-    fn assert_true(self, cond: Bool, message: String) raises:
+    fn assert_true(self, cond: Bool, message: String):
         """
-        Wraps testing.assert_true, raises Error on assertion failure.
+        Wraps testing.assert_true.
         """
         _ = testing.assert_true(cond, message)

--- a/pytest_mojo/plugin.py
+++ b/pytest_mojo/plugin.py
@@ -55,7 +55,7 @@ class MojoTestFile(File):
             for line in lines:
                 if "warning:" in line:
                     yield MojoTestItem.from_parent(
-                        self, name="warning", spec=dict(stdout=[line], code=0)
+                        self, name="warning", spec=dict(stdout=[line], code=1)
                     )
 
         # extract result stdout into one or more MojoTestItem

--- a/pytest_mojo/plugin.py
+++ b/pytest_mojo/plugin.py
@@ -55,7 +55,7 @@ class MojoTestFile(File):
             for line in lines:
                 if "warning:" in line:
                     yield MojoTestItem.from_parent(
-                        self, name="warning", spec=dict(stdout=[line], code=1)
+                        self, name="warning", spec=dict(stdout=[line], code=0)
                     )
 
         # extract result stdout into one or more MojoTestItem
@@ -73,7 +73,7 @@ class MojoTestFile(File):
                     yield MojoTestItem.from_parent(
                         self,
                         name=cur_item,
-                        spec=dict(stdout=item_stdout, code=process.returncode),
+                        spec=dict(stdout=item_stdout, code=0),
                     )
                 cur_item = line
                 item_stdout = []

--- a/pytest_mojo/plugin.py
+++ b/pytest_mojo/plugin.py
@@ -2,7 +2,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-from pytest import Package, File, Item
+from pytest import File, Item, Package
 
 MOJO_CMD = ["mojo", "run", "-I", "."]
 """
@@ -17,6 +17,11 @@ Examples of test prefix: `test_something.mojo` or `test_xyz.🔥`
 TEST_ITEM_PREFIX = "#"
 """
 By convention, a comment line (hashtag) signals the test item name.
+"""
+
+TEST_FAILED_PREFIX = "ASSERT ERROR"
+"""
+This is the prefix used in Mojo assertions in the testing module
 """
 
 
@@ -66,7 +71,9 @@ class MojoTestFile(File):
             if line.startswith(TEST_ITEM_PREFIX):
                 if cur_item is not None:
                     yield MojoTestItem.from_parent(
-                        self, name=cur_item, spec=dict(stdout=item_stdout, code=0)
+                        self,
+                        name=cur_item,
+                        spec=dict(stdout=item_stdout, code=process.returncode),
                     )
                 cur_item = line
                 item_stdout = []
@@ -83,11 +90,13 @@ class MojoTestFile(File):
 
 class MojoTestItem(Item):
     def __init__(self, *, name: str, parent, spec: dict[str, Any], **kwargs):
-        super().__init__(name, parent, **kwargs)
+        super().__init__(name.removeprefix(TEST_ITEM_PREFIX), parent, **kwargs)
         self.spec = spec
 
     def runtest(self):
-        if self.spec["code"] != 0:
+        if self.spec.get("code") or any(
+            item.startswith(TEST_FAILED_PREFIX) for item in self.spec["stdout"]
+        ):
             raise MojoTestException(self, self.spec["stdout"][-1])
 
     def repr_failure(self, excinfo):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pytest-mojo",
-    version="0.1.0",
+    version="0.1.1",
     packages=find_packages(),
     entry_points={"pytest11": ["mojo = pytest_mojo.plugin"]},
     install_requires=["pytest"],


### PR DESCRIPTION
FIxes #1 

Now tests fail either by an unhandled Error or by a failed assertion from the Mojo standard lib testing module.
By just using the standard lib assertions, it is possible to collect all the items, even if one of them fails in between.

I Also added Integration Tests as a GitHub Workflow, for that to work you need to setup the MODULAR_AUTH GitHub secret with the value of the Modular key you can find at https://developer.modular.com/download, check the curl command.

The documentation is not updated yet, I am waiting for us to discuss the implementation to do it.