### PR TITLE
Fixes to support API change in mojo 0.6.0.

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -2,7 +2,7 @@ name: mojo-pytest
 channels:
   - defaults
 dependencies:
-  - python=3.11
+  - python=3.12
   - pytest>=7.4.*
   - pip
   - pip:

--- a/example/tests/util.mojo
+++ b/example/tests/util.mojo
@@ -17,4 +17,7 @@ struct MojoTest:
         """
         Wraps testing.assert_true.
         """
-        _ = testing.assert_true(cond, message)
+        try:
+            testing.assert_true(cond, message)
+        except e:
+            print(e)

--- a/pytest_mojo/plugin.py
+++ b/pytest_mojo/plugin.py
@@ -24,7 +24,7 @@ TEST_ITEM_PREFIX = "#"
 By convention, a comment line (hashtag) signals the test item name.
 """
 
-TEST_FAILED_PREFIX = "ASSERT ERROR"
+TEST_FAILED_PREFIX = "AssertionError: "
 """
 This is the prefix used in Mojo assertions in the testing module
 """

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pytest-mojo",
-    version="0.2.0",
+    version="0.6.0",
     packages=find_packages(),
     entry_points={"pytest11": ["mojo = pytest_mojo.plugin"]},
     install_requires=["pytest"],


### PR DESCRIPTION
- The example tests/util.mojo is changed. We now need to catch the assertion failure, and print it, because the stdlib testing module no longer prints the same message to the console.
- Update plugin version to correspond to currently support mojo version (0.6)

cc @lleites 