### PR TITLE
Fixes to support API change in mojo 0.7.0.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           curl https://get.modular.com | MODULAR_AUTH=${{ secrets.MODULAR_AUTH }} sh -
           modular auth ${{ secrets.MODULAR_AUTH }}
-          modular install --install-version 0.6.1 mojo
+          modular install --install-version 0.7.0 mojo
 
           pip install .
       - name: Integration Tests

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ pytest
 ============================= test session starts ==============================
 platform darwin -- Python 3.12.0, pytest-7.4.0, pluggy-1.0.0
 rootdir: /Users/guidorice/mojo/mojo-pytest
-plugins: mojo-0.6.0
+plugins: mojo-0.7.0
 collected 17 items                                                             
 
 example/tests/suffix_test.mojo .                                         [  5%]

--- a/example/tests/test_warning.mojo
+++ b/example/tests/test_warning.mojo
@@ -9,10 +9,11 @@ fn test_warning_is_collected():
     """
     Cause a compiler warning.
 
-    > warning: 'x' was declared as a 'var' but never mutated, consider switching to a 'let'")
+    > warning: unreachable code after return statement
 
     This can be captured by running `pytest -W error` (warning -> error mode).
     """
     let test = MojoTest("compiler warning")
-    var x = 100
+    return
+    let x = 100
     print(x)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pytest-mojo",
-    version="0.6.0",
+    version="0.7.0",
     packages=find_packages(),
     entry_points={"pytest11": ["mojo = pytest_mojo.plugin"]},
     install_requires=["pytest"],


### PR DESCRIPTION
- Update CI script to use mojo 0.7
- Fix test regression with 0.7.
- Add `--mojo-assertions` option (`-D MOJO_ENABLE_ASSERTIONS`), but YMMV . Closes #8, however see warnings in that issue about the usefulness of the mojo assertions.