### PR TITLE
Fixes to support API change in mojo 24.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           curl https://get.modular.com | MODULAR_AUTH=${{ secrets.MODULAR_AUTH }} sh -
           modular auth ${{ secrets.MODULAR_AUTH }}
-          modular install --install-version 0.7.0 mojo
+          modular install --install-version 24.1.0 mojo
 
           pip install .
       - name: Integration Tests
@@ -29,17 +29,24 @@ jobs:
 
           # Tests that should fail
           if pytest example/tests/mod_a ; then
-            echo "This tests should fail"
+            echo "expected pytest exit code 0"
             exit 1
           fi
 
           # Test should fail because I am passing options for checking warnings
           rm -rf ~/.modular/.mojo_cache
           if pytest -W error example/tests/test_warning.mojo ; then
-            echo "This tests should fail"
+            echo "expected pytest exit code 0"
             exit 1
           fi
 
           # Test should not fail because I am not checking for warning
           rm -rf ~/.modular/.mojo_cache
           pytest example/tests/test_warning.mojo
+
+          # Test should fail because debug_assert is enabled
+          rm -rf ~/.modular/.mojo_cache
+          if pytest --mojo-assertions example/tests/test_debug_assert.mojo; then
+            echo "expected pytest exit code 0"
+            exit 1
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,16 @@ jobs:
         run: |
           curl https://get.modular.com | MODULAR_AUTH=${{ secrets.MODULAR_AUTH }} sh -
           modular auth ${{ secrets.MODULAR_AUTH }}
-          modular install --install-version 24.1.0 mojo
-
+          # modular install --install-version 24.1.0 mojo
+          # TODO: fix version pinning of mojo https://github.com/modularml/mojo/issues/1887
+          modular install mojo
           pip install .
       - name: Integration Tests
         run: |
           export MODULAR_HOME="/home/runner/.modular"
           export PATH="/home/runner/.modular/pkg/packages.modular.com_mojo/bin:$PATH"
+
+          mojo --version
 
           # check test collection (this count needs to be updated manually when tests are updated)
           pytest | grep "collected 17 items"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,35 +21,4 @@ jobs:
         run: |
           export MODULAR_HOME="/home/runner/.modular"
           export PATH="/home/runner/.modular/pkg/packages.modular.com_mojo/bin:$PATH"
-
-          mojo --version
-
-          # check test collection (this count needs to be updated manually when tests are updated)
-          pytest | grep "collected 17 items"
-
-          # Tests that do not fail
-          pytest example/tests/mod_b
-
-          # Tests that should fail
-          if pytest example/tests/mod_a ; then
-            echo "expected pytest exit code 0"
-            exit 1
-          fi
-
-          # Test should fail because I am passing options for checking warnings
-          rm -rf ~/.modular/.mojo_cache
-          if pytest -W error example/tests/test_warning.mojo ; then
-            echo "expected pytest exit code 0"
-            exit 1
-          fi
-
-          # Test should not fail because I am not checking for warning
-          rm -rf ~/.modular/.mojo_cache
-          pytest example/tests/test_warning.mojo
-
-          # Test should fail because debug_assert is enabled
-          rm -rf ~/.modular/.mojo_cache
-          if pytest --mojo-assertions example/tests/test_debug_assert.mojo; then
-            echo "expected pytest exit code 0"
-            exit 1
-          fi
+          make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+.PHONY: test
+
+test:
+	mojo --version
+
+# check test collection (this count needs to be updated manually when tests are updated)
+	pytest | grep "collected 18 items"
+
+# Tests that do not fail
+	pytest example/tests/mod_b
+
+# Tests that should fail
+	pytest example/tests/mod_a ; \
+		if [ $$? -eq 0 ]; then \
+			echo "expected pytest non-zero exit code"; \
+			exit 1; \
+		fi
+
+# Test should fail because I am passing options for checking warnings
+	pytest -W error example/tests/test_warning.mojo; \
+		if [ $$? -eq 0 ]; then \
+			echo "expected pytest non-zero exit code"; \
+			exit 1; \
+		fi
+
+# Test should not fail because I am not checking for warnings
+	pytest example/tests/test_warning.mojo
+
+# Test should fail because --mojo-assertions is enabled
+	pytest --mojo-assertions example/tests/test_debug_assert.mojo ; \
+		if [ $$? -eq 0 ]; then \
+			echo "expected pytest non-zero exit code"; \
+			exit 1; \
+		fi
+
+# Test should not fail because I am not checking for debug assertions
+	pytest example/tests/test_debug_assert.mojo

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ and exit codes.
     raised or if an unhandled exception occurs. Note that with unhandled exceptions, subsequent tests will not be
     collected.
 - Mojo compiler warnings may optionally be handled as test failures, using the `pytest -W error` mode.
-- Mojo debug assertion errors may optionally be handled as test failures, using the `pytest --mojo--assertions` mode.
+- Mojo debug assertion errors may optionally be handled as test failures, using the `pytest --mojo-assertions` mode.
 
 ## Usage
 
@@ -82,13 +82,14 @@ $ pytest
 ============================= test session starts ==============================
 platform darwin -- Python 3.12.0, pytest-7.4.0, pluggy-1.0.0
 rootdir: /Users/guidorice/mojo/mojo-pytest
-plugins: mojo-0.7.0
-collected 17 items                                                             
+plugins: mojo-24.1.0
+collected 18 items                                                             
 
 example/tests/suffix_test.mojo .                                         [  5%]
-example/tests/test_warning.mojo .                                        [ 11%]
-example/tests/mod_a/test_convert.mojo .                                  [ 17%]
-example/tests/mod_a/test_convert_different.mojo .                        [ 23%]
+example/tests/test_debug_assert.mojo .                                   [ 11%]
+example/tests/test_warning.mojo .                                        [ 16%]
+example/tests/mod_a/test_convert.mojo .                                  [ 22%]
+example/tests/mod_a/test_convert_different.mojo .                        [ 27%]
 example/tests/mod_a/test_maths.mojo ....F.......                         [ 94%]
 example/tests/mod_b/test_greet.mojo .                                    [100%]
 
@@ -97,7 +98,7 @@ _______________________________  maths more: 42 ________________________________
 (<MojoTestItem  maths more: 42>, 'AssertionError: bad maths: 42')
 =========================== short test summary info ============================
 FAILED example/tests/mod_a/test_maths.mojo:: maths more: 42
-========================= 1 failed, 16 passed in 0.46s =========================
+========================= 1 failed, 17 passed in 2.54s =========================
 ```
 
 ## Links

--- a/example/mod_a/impl.mojo
+++ b/example/mod_a/impl.mojo
@@ -1,12 +1,12 @@
 fn maths(x: Int) -> Int:
-    let THE_ANSWER = 42
+    var THE_ANSWER = 42
     if x == THE_ANSWER:
         return x
     return x**2
 
 
 fn convert(x: Int) -> SIMD[DType.float64]:
-    let tmp: SIMD[DType.float64] = x
+    var tmp: SIMD[DType.float64] = x
     return tmp
 
 

--- a/example/tests/mod_a/test_convert.mojo
+++ b/example/tests/mod_a/test_convert.mojo
@@ -7,8 +7,8 @@ fn main() raises:
 
 
 fn test_convert() raises:
-    let test = MojoTest("convert")
-    let x: Int = 42
-    let expect = SIMD[DType.float64](42)
-    let result = convert(x)
+    var test = MojoTest("convert")
+    var x: Int = 42
+    var expect = SIMD[DType.float64](42)
+    var result = convert(x)
     test.assert_true(result == expect, "convert unexpected result: " + String(result))

--- a/example/tests/mod_a/test_convert_different.mojo
+++ b/example/tests/mod_a/test_convert_different.mojo
@@ -7,8 +7,8 @@ fn main() raises:
 
 
 fn test_convert_different() raises:
-    let test = MojoTest("convert_different")
-    let x: Int = 8
-    let expect = SIMD[DType.float16](8)
-    let result = convert_different(x)
+    var test = MojoTest("convert_different")
+    var x: Int = 8
+    var expect = SIMD[DType.float16](8)
+    var result = convert_different(x)
     test.assert_true(result == expect, "convert unexpected result: " + String(result))

--- a/example/tests/mod_a/test_maths.mojo
+++ b/example/tests/mod_a/test_maths.mojo
@@ -9,22 +9,22 @@ fn main() raises:
 
 
 fn test_maths() raises:
-    let test = MojoTest("maths")
-    let result = maths(8)
-    let expect = 64
+    var test = MojoTest("maths")
+    var result = maths(8)
+    var expect = 64
     test.assert_true(result == expect, "maths unexpected result: " + String(result))
 
 
 fn test_maths_more() raises:
-    let test = MojoTest("maths more")
-    let result = maths(9)
-    let expect = 81
+    var test = MojoTest("maths more")
+    var result = maths(9)
+    var expect = 81
     test.assert_true(result == expect, "maths unexpected result: " + String(result))
 
 
 fn test_maths_lotsmore() raises:
     for i in range(40, 50):
-        let test = MojoTest("maths more: " + String(i))
-        let result = maths(i)
+        var test = MojoTest("maths more: " + String(i))
+        var result = maths(i)
         if result == i:
             test.assert_true(False, "bad maths: " + String(i))

--- a/example/tests/mod_b/test_greet.mojo
+++ b/example/tests/mod_b/test_greet.mojo
@@ -7,7 +7,7 @@ fn main() raises:
 
 
 fn test_greet() raises:
-    let test = MojoTest("greet result")
-    let result = greet("guido")
-    let expect = "Hey guido"
+    var test = MojoTest("greet result")
+    var result = greet("guido")
+    var expect = "Hey guido"
     test.assert_true(result == expect, "greet unexpected result: " + String(result))

--- a/example/tests/suffix_test.mojo
+++ b/example/tests/suffix_test.mojo
@@ -9,5 +9,5 @@ fn main() raises:
 
 
 fn test() raises:
-    let test = MojoTest("test suffix discovery")
+    var test = MojoTest("test suffix discovery")
     test.assert_true(True, "")

--- a/example/tests/test_debug_assert.mojo
+++ b/example/tests/test_debug_assert.mojo
@@ -1,0 +1,19 @@
+from example.tests.util import MojoTest
+
+
+fn main() raises:
+    test_assertion_is_collected()
+
+
+fn test_assertion_is_collected():
+    """
+    Cause a debug assertion.
+
+    > Assert Error:Intentional debug_assert failure
+
+    This can be captured by running `pytest --mojo-assertions` (warning -> error mode).
+    """
+    var test = MojoTest("debug_assert")
+
+    var condition = False
+    debug_assert(condition, "Intentional debug_assert failure")

--- a/example/tests/test_warning.mojo
+++ b/example/tests/test_warning.mojo
@@ -13,7 +13,7 @@ fn test_warning_is_collected():
 
     This can be captured by running `pytest -W error` (warning -> error mode).
     """
-    let test = MojoTest("compiler warning")
+    var test = MojoTest("compiler warning")
     return
-    let x = 100
+    var x = 100
     print(x)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pytest-mojo",
-    version="0.7.0",
+    version="24.1.0",
     packages=find_packages(),
     entry_points={"pytest11": ["mojo = pytest_mojo.plugin"]},
     install_requires=["pytest"],


### PR DESCRIPTION
- Add `--mojo-assertions` to test runner, as it is working now.
- Fix typo in Readme.
- Fix some warnings about `var` vs `let` which cropped up in mojo 24.1
- Refactor integration tests into a Makefile
- Update version numbering to track new Max/Mojo versioning: https://docs.modular.com/mojo/changelog
