### PR TITLE
Fixes to support mojo v24.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           curl https://get.modular.com | sh -
           modular auth ${{ secrets.MODULAR_AUTH }}
-          modular install --install-version 24.2.1-2f0dcf11-release mojo
+          modular install --install-version 24.3.0-9882e19d-release mojo
           pip install .
       - name: Integration Tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           curl https://get.modular.com | sh -
           modular auth ${{ secrets.MODULAR_AUTH }}
-          modular install --install-version 24.3.0-9882e19d-release mojo
+          modular install --install-version 24.3.0 mojo
           pip install .
       - name: Integration Tests
         run: |

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ example
 ```text
 $ pytest
 ============================= test session starts ==============================
-platform darwin -- Python 3.12.0, pytest-7.4.0, pluggy-1.0.0
+platform darwin -- Python 3.11.9, pytest-7.4.3, pluggy-1.3.0
 rootdir: /Users/guidorice/mojo/mojo-pytest
-plugins: mojo-24.2.1
+plugins: mojo-24.3.0
 collected 18 items                                                             
 
 example/tests/suffix_test.mojo .                                         [  5%]
@@ -96,10 +96,10 @@ example/tests/mod_b/test_greet.mojo .                                    [100%]
 
 =================================== FAILURES ===================================
 _______________________________  maths more: 42 ________________________________
-(<MojoTestItem  maths more: 42>, 'AssertionError: bad maths: 42')
+(<MojoTestItem  maths more: 42>, 'At /.../mojo-pytest/example/tests/util.mojo:21:32: AssertionError: bad maths: 42')
 =========================== short test summary info ============================
 FAILED example/tests/mod_a/test_maths.mojo:: maths more: 42
-========================= 1 failed, 17 passed in 2.54s =========================
+========================= 1 failed, 17 passed in 1.82s =========================
 ```
 
 ## Links

--- a/pytest_mojo/plugin.py
+++ b/pytest_mojo/plugin.py
@@ -115,7 +115,7 @@ class MojoTestItem(Item):
 
     def runtest(self):
         if self.spec.get("code") or any(
-            item.startswith(TEST_FAILED_PREFIX) for item in self.spec["stdout"]
+            TEST_FAILED_PREFIX in item for item in self.spec["stdout"]
         ):
             raise MojoTestException(self, self.spec["stdout"][-1])
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pytest-mojo",
-    version="24.2.1",
+    version="24.3.0",
     packages=find_packages(),
     entry_points={"pytest11": ["mojo = pytest_mojo.plugin"]},
     install_requires=["pytest"],


### PR DESCRIPTION
- Fix a regression bug where test failures were not being caught by the plugin.
- Updates Github CI runner to mojo v24.3.