### PR TITLE
Enhance MojoTest class in util.mojo to print the call_location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ pytest
 ============================= test session starts ==============================
 platform darwin -- Python 3.11.9, pytest-7.4.3, pluggy-1.3.0
 rootdir: /Users/guidorice/mojo/mojo-pytest
-plugins: mojo-24.3.0
+plugins: mojo-24.3.1
 collected 18 items                                                             
 
 example/tests/suffix_test.mojo .                                         [  5%]
@@ -96,10 +96,10 @@ example/tests/mod_b/test_greet.mojo .                                    [100%]
 
 =================================== FAILURES ===================================
 _______________________________  maths more: 42 ________________________________
-(<MojoTestItem  maths more: 42>, 'At /.../mojo-pytest/example/tests/util.mojo:21:32: AssertionError: bad maths: 42')
+(<MojoTestItem  maths more: 42>, '/.../mojo-pytest/example/tests/mod_a/test_maths.mojo:30:29: AssertionError: bad maths: 42')
 =========================== short test summary info ============================
 FAILED example/tests/mod_a/test_maths.mojo:: maths more: 42
-========================= 1 failed, 17 passed in 1.82s =========================
+========================= 1 failed, 17 passed in 1.90s =========================
 ```
 
 ## Links

--- a/example/tests/util.mojo
+++ b/example/tests/util.mojo
@@ -1,4 +1,4 @@
-import testing
+from builtin._location import __call_location
 
 
 @value
@@ -13,11 +13,11 @@ struct MojoTest:
         self.test_name = test_name
         print("# " + test_name)
 
+    @always_inline("nodebug")
     fn assert_true(self, cond: Bool, message: String):
         """
-        Wraps testing.assert_true.
+        If the condition is false, prints MojoPytestError and call location.
         """
-        try:
-            testing.assert_true(cond, message)
-        except e:
-            print(e)
+        if not cond:
+            var call_loc = __call_location()
+            print(call_loc.file_name, ":", str(call_loc.line), ":", str(call_loc.col), ": ", "AssertionError: " , message, sep="")

--- a/pytest_mojo/plugin.py
+++ b/pytest_mojo/plugin.py
@@ -25,9 +25,9 @@ TEST_ITEM_PREFIX = "#"
 By convention, a comment line (hashtag) signals the test item name.
 """
 
-TEST_FAILED_PREFIX = "AssertionError: "
+TEST_FAILED_TAG = "AssertionError: "
 """
-This is the prefix used in Mojo assertions in the testing module
+This is the tag used in Mojo assertions in the util.mojo module.
 """
 
 
@@ -115,7 +115,7 @@ class MojoTestItem(Item):
 
     def runtest(self):
         if self.spec.get("code") or any(
-            TEST_FAILED_PREFIX in item for item in self.spec["stdout"]
+            TEST_FAILED_TAG in item for item in self.spec["stdout"]
         ):
             raise MojoTestException(self, self.spec["stdout"][-1])
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pytest-mojo",
-    version="24.3.0",
+    version="24.3.1",
     packages=find_packages(),
     entry_points={"pytest11": ["mojo = pytest_mojo.plugin"]},
     install_requires=["pytest"],


### PR DESCRIPTION
In example MojoTest utility, instead of wrapping the testing module, print the call_location of failed assertions, using the  stdlib.

Closes #9 

