### PR TITLE
Updates for mojo v24.6

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python>=3.10
   # modular MAX installs mojo as well
-  - max=24.5
+  - max=24.6
   - pytest>=7.4
   # python-xdist is optional: https://github.com/guidorice/mojo-pytest/wiki#2024-07-17-here-is-a-performance-tip
   - pytest-xdist

--- a/example_src/my_package/fibonacci.mojo
+++ b/example_src/my_package/fibonacci.mojo
@@ -5,8 +5,8 @@ fn fibonacci(n: Int) -> Int:
     if n <= 1:
         return n
     
-    var a = 0
-    var b = 1
+    a = 0
+    b = 1
     for _ in range(2, n + 1):
         a, b = b, a + b
     return b

--- a/example_src/my_package/random_tensor.mojo
+++ b/example_src/my_package/random_tensor.mojo
@@ -6,5 +6,5 @@ fn random_tensor[T: DType]() raises -> Tensor[T]:
     """
     Wraps Tensor.rand() and multiplies a few tensors.
     """
-    var Shape = TensorShape(100, 1)
+    Shape = TensorShape(100, 1)
     return Tensor[T].rand(Shape) * Tensor[T].rand(Shape) * Tensor[T].rand(Shape)

--- a/example_tests/my_package/test_fibonacci.mojo
+++ b/example_tests/my_package/test_fibonacci.mojo
@@ -7,8 +7,8 @@ def test_fibonacci():
     """
     Test fibonacci 10th number.
     """
-    var expect = 55
-    var got = fibonacci(10)
+    expect = 55
+    got = fibonacci(10)
     assert_equal(got, expect)
 
 
@@ -16,8 +16,8 @@ def test_fibonacci_reference():
     """
     Test mojo fibonacci versus python "reference" implementation.
     """
-    var py = Python.import_module("my_package.fibonacci")
+    py = Python.import_module("my_package.fibonacci")
     for n in range(0, 10):
-        var expect = py.fibonacci(n)
-        var got = fibonacci(n)
+        expect = py.fibonacci(n)
+        got = fibonacci(n)
         assert_equal(got, expect)

--- a/example_tests/my_package/test_random_tensor.mojo
+++ b/example_tests/my_package/test_random_tensor.mojo
@@ -7,7 +7,7 @@ def test_random_tensor():
     Validate the random_tensor module in my_package.
     """
     alias T = DType.float64
-    var t = random_tensor[T]()
-    var sample_value = t[0]
+    t = random_tensor[T]()
+    sample_value = t[0]
     assert_false(isnan(sample_value))
     assert_true(isfinite(sample_value))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [project]
 name = "pytest-mojo"
-version = "v24.5"
+version = "v24.6"
 description = "Mojo🔥 language test runner plugin for pytest. (aka pytest-mojo)"
 authors = [{name = "Alex G Rice", email = "alex@ricegeo.dev"}]
 license = {file = "LICENSE"}
 requires-python = ">=3.10"
+
 [build-system]
 requires = ["setuptools>=45", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
- update conda env to use mojo 24.6

Side-car change
- use implicitly declared variables, just for simplicity